### PR TITLE
[CHORE] Speed up ensemble list endpoint

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+## Description
+
 ## Which app(s)/packages is this PR for?
 
 === Apps ===

--- a/apps/backend/ensembles/models/arrangement.py
+++ b/apps/backend/ensembles/models/arrangement.py
@@ -51,6 +51,17 @@ class Arrangement(models.Model):
 
     @property
     def latest_version(self):
+        prefetched_latest_versions = getattr(self, "prefetched_latest_versions", None)
+        if prefetched_latest_versions is not None:
+            return prefetched_latest_versions[0] if prefetched_latest_versions else None
+
+        prefetched_versions = getattr(self, "_prefetched_objects_cache", {}).get("versions")
+        if prefetched_versions is not None:
+            for version in prefetched_versions:
+                if version.is_latest:
+                    return version
+            return None
+
         return self.versions.filter(is_latest=True).first()
 
     @property

--- a/apps/backend/ensembles/serializers.py
+++ b/apps/backend/ensembles/serializers.py
@@ -1,4 +1,5 @@
 import io
+from collections import defaultdict
 from rest_framework import serializers
 from rest_framework import status
 
@@ -13,6 +14,7 @@ from ensembles.models import (
     Arrangement,
     ArrangementVersion,
     PartBook,
+    PartAsset,
     PartName,
     Commit,
 )
@@ -98,10 +100,28 @@ class EnsembleSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ["slug", "join_link", "is_admin", "userships"]
 
+    def _get_request_user_usership(self, obj):
+        request = self.context.get("request")
+        if not request or not request.user.is_authenticated:
+            return None
+
+        prefetched_userships = getattr(obj, "_prefetched_objects_cache", {}).get("userships")
+        if prefetched_userships is None:
+            return EnsembleUsership.objects.filter(ensemble=obj, user=request.user).first()
+
+        for usership in prefetched_userships:
+            if usership.user_id == request.user.id:
+                return usership
+        return None
+
     def get_is_admin(self, obj):
         request = self.context.get("request")
         if request and request.user.is_authenticated:
-            return request.user.is_ensemble_admin(obj)
+            if obj.owner_id == request.user.id:
+                return True
+            ship = self._get_request_user_usership(obj)
+            return ship is not None and ship.role == EnsembleUsership.Role.ADMIN
+        return False
 
     def get_join_link(self, obj):
         """Generate join link if user is owner or admin"""
@@ -116,16 +136,13 @@ class EnsembleSerializer(serializers.ModelSerializer):
                 return f"{frontend_url.rstrip('/')}/join/{token}"
 
             # Check if user has admin role
-            try:
-                ship = EnsembleUsership.objects.get(ensemble=obj, user=request.user)
-                if ship.role == EnsembleUsership.Role.ADMIN:
-                    token = obj.get_or_create_invite_token()
-                    frontend_url = getattr(
-                        settings, "FRONTEND_URL", "http://localhost:5173"
-                    )
-                    return f"{frontend_url.rstrip('/')}/join/{token}"
-            except EnsembleUsership.DoesNotExist:
-                pass
+            ship = self._get_request_user_usership(obj)
+            if ship is not None and ship.role == EnsembleUsership.Role.ADMIN:
+                token = obj.get_or_create_invite_token()
+                frontend_url = getattr(
+                    settings, "FRONTEND_URL", "http://localhost:5173"
+                )
+                return f"{frontend_url.rstrip('/')}/join/{token}"
 
             return None
         return None
@@ -134,6 +151,9 @@ class EnsembleSerializer(serializers.ModelSerializer):
         """Get userships details"""
         request = self.context.get("request")
         if request and request.user.is_authenticated:
+            userships = getattr(obj, "_prefetched_objects_cache", {}).get("userships")
+            if userships is None:
+                userships = EnsembleUsership.objects.filter(ensemble=obj).select_related("user")
             return [
                 # TODO[SC-278]: Usership serializer
                 {
@@ -142,7 +162,7 @@ class EnsembleSerializer(serializers.ModelSerializer):
                     "role": usership.role,
                     "date_joined": usership.date_joined,
                 }
-                for usership in EnsembleUsership.objects.filter(ensemble=obj)
+                for usership in userships
             ]
         return None
 
@@ -158,12 +178,33 @@ class EnsembleSerializer(serializers.ModelSerializer):
             parts = obj.part_names.all().order_by(
                 Coalesce("order", Value(999999, output_field=IntegerField())), "id"
             )
+            part_name_ids = [part.id for part in parts]
+
+            arrangement_titles_by_part_name_id = defaultdict(list)
+            if part_name_ids:
+                part_assets = (
+                    PartAsset.objects.filter(
+                        part_name_id__in=part_name_ids,
+                        arrangement_version__arrangement__ensemble=obj,
+                        arrangement_version__is_latest=True,
+                    )
+                    .select_related("arrangement_version__arrangement")
+                    .order_by(
+                        "arrangement_version__arrangement__mvt_no",
+                        "arrangement_version__arrangement__id",
+                    )
+                )
+                for asset in part_assets:
+                    arrangement_titles_by_part_name_id[asset.part_name_id].append(
+                        asset.arrangement_version.arrangement.title
+                    )
+
             # Keep a stable, typed shape for the frontend
             return [
                 {
                     "id": part.id,
                     "display_name": part.display_name,
-                    "arrangements": part.get_arrangements(),
+                    "arrangements": arrangement_titles_by_part_name_id.get(part.id, []),
                     "order": part.order,
                 }
                 for part in parts
@@ -174,11 +215,13 @@ class EnsembleSerializer(serializers.ModelSerializer):
         request = self.context.get("request")
         if not request or not request.user.is_authenticated:
             return []
-        books = (
-            PartBook.objects.filter(ensemble=obj)
-            .select_related("part_name")
-            .order_by("part_name__display_name", "-revision")
-        )
+        books = getattr(obj, "_prefetched_objects_cache", {}).get("part_books")
+        if books is None:
+            books = (
+                PartBook.objects.filter(ensemble=obj)
+                .select_related("part_name")
+                .order_by("part_name__display_name", "-revision")
+            )
         result = []
         for book in books:
             item = {
@@ -193,11 +236,52 @@ class EnsembleSerializer(serializers.ModelSerializer):
                 "is_rendered": book.is_rendered,
                 "download_url": None,
             }
-            if book.is_rendered and default_storage.exists(book.pdf_file_key):
+            # Avoid a storage existence check on list endpoints; this can be slow on remote storage.
+            if book.is_rendered:
                 file_url = default_storage.url(book.pdf_file_key)
                 item["download_url"] = request.build_absolute_uri(file_url)
             result.append(item)
         return result
+
+
+class EnsembleListSerializer(serializers.ModelSerializer):
+    is_admin = serializers.SerializerMethodField(read_only=True)
+    arrangements_count = serializers.SerializerMethodField(read_only=True)
+
+    class Meta:
+        model = Ensemble
+        fields = [
+            "id",
+            "name",
+            "slug",
+            "is_admin",
+            "arrangements_count",
+            "part_books_generating",
+            "latest_part_book_revision",
+        ]
+        read_only_fields = fields
+
+    def get_is_admin(self, obj):
+        request = self.context.get("request")
+        if not request or not request.user.is_authenticated:
+            return False
+        if obj.owner_id == request.user.id:
+            return True
+        prefetched_userships = getattr(obj, "_prefetched_objects_cache", {}).get("userships")
+        if prefetched_userships is not None:
+            for usership in prefetched_userships:
+                if usership.user_id == request.user.id and usership.role == EnsembleUsership.Role.ADMIN:
+                    return True
+            return False
+        return EnsembleUsership.objects.filter(
+            ensemble=obj, user=request.user, role=EnsembleUsership.Role.ADMIN
+        ).exists()
+
+    def get_arrangements_count(self, obj):
+        annotated_count = getattr(obj, "arrangements_count", None)
+        if annotated_count is not None:
+            return annotated_count
+        return obj.arrangements.count()
 
 
 class EnsemblePartNameMergeSerializer(serializers.Serializer):

--- a/apps/backend/ensembles/views.py
+++ b/apps/backend/ensembles/views.py
@@ -8,7 +8,7 @@ from rest_framework.decorators import permission_classes
 
 from django.core.files.storage import default_storage
 from django.core.exceptions import ValidationError
-from django.db.models import Q
+from django.db.models import Q, Prefetch, Count
 from django.conf import settings
 from django.http import FileResponse
 
@@ -19,11 +19,13 @@ from ensembles.models import (
     EnsembleUsership,
     PartAsset,
     PartName,
+    PartBook,
     Commit,
     UserScoreVersion,
 )
 from ensembles.serializers import (
     EnsembleSerializer,
+    EnsembleListSerializer,
     ArrangementSerializer,
     ArrangementVersionSerializer,
     CreateArrangementVersionMsczSerializer,
@@ -44,15 +46,54 @@ class EnsembleViewSet(viewsets.ModelViewSet):
     lookup_field = "slug"  # use slug instead of pk
     permission_classes = [IsAuthenticated]
 
+    def get_serializer_class(self):
+        if self.action == "list":
+            return EnsembleListSerializer
+        return EnsembleSerializer
+
     def get_queryset(self):
         """Filter ensembles to only those the user has access to"""
         user = self.request.user
         if not user.is_authenticated:
             return Ensemble.objects.none()
-        
-        # Get ensembles where user is owner or has usership
-        return Ensemble.objects.filter(
+
+        base_qs = Ensemble.objects.filter(
             Q(owner=user) | Q(userships__user=user)
+        ).select_related("owner")
+
+        if self.action == "list":
+            # Lightweight list payload: do not fetch nested arrangements or part-book details.
+            return base_qs.annotate(
+                arrangements_count=Count("arrangements", distinct=True)
+            ).prefetch_related(
+                Prefetch(
+                    "userships",
+                    queryset=EnsembleUsership.objects.filter(user=user).only("id", "user_id", "ensemble_id", "role"),
+                )
+            ).distinct()
+
+        # Full detail payload for retrieve/update and custom actions.
+        arrangements_queryset = Arrangement.objects.select_related("ensemble").prefetch_related(
+            Prefetch(
+                "versions",
+                queryset=ArrangementVersion.objects.filter(is_latest=True),
+                to_attr="prefetched_latest_versions",
+            )
+        )
+
+        return base_qs.prefetch_related(
+            Prefetch("arrangements", queryset=arrangements_queryset),
+            Prefetch(
+                "userships",
+                queryset=EnsembleUsership.objects.select_related("user"),
+            ),
+            "part_names",
+            Prefetch(
+                "part_books",
+                queryset=PartBook.objects.select_related("part_name").order_by(
+                    "part_name__display_name", "-revision"
+                ),
+            ),
         ).distinct()
 
     def perform_create(self, serializer):

--- a/apps/frontend/src/pages/ensembles/EnsemblesPage.tsx
+++ b/apps/frontend/src/pages/ensembles/EnsemblesPage.tsx
@@ -16,9 +16,10 @@ import {
 } from '@mantine/core';
 import { IconMusic, IconEye } from '@tabler/icons-react';
 import { apiService } from '../../services/apiService';
+import type { Ensemble } from '../../services/apiService';
 
 const EnsemblesPage = () => {
-  const [ensembles, setEnsembles] = useState<any[]>([]);
+  const [ensembles, setEnsembles] = useState<Ensemble[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<any>(null);
 
@@ -92,7 +93,7 @@ const EnsemblesPage = () => {
                 </Group>
 
                 <Text c="dimmed" size="sm" flex={1}>
-                  {ensemble.arrangements?.length || 0} arrangement{ensemble.arrangements?.length !== 1 ? 's' : ''}
+                  {(ensemble.arrangements_count ?? ensemble.arrangements?.length ?? 0)} arrangement{(ensemble.arrangements_count ?? ensemble.arrangements?.length ?? 0) !== 1 ? 's' : ''}
                 </Text>
 
                 <Group justify="space-between" mt="auto">

--- a/apps/frontend/src/services/apiService.ts
+++ b/apps/frontend/src/services/apiService.ts
@@ -85,8 +85,8 @@ export interface Ensemble {
   id: number,
   name: string,
   slug: string,
-  // TODO: Remove Arrangements from ensemble, makes the request too slow
-  arrangements: Arrangement[],
+  arrangements?: Arrangement[],
+  arrangements_count?: number,
   join_link?: string | null,
   is_admin: boolean, //if the requesting user is an admin in the ensemble
   // Backend returns `part_names`. Keep `part_name` for backward compatibility.


### PR DESCRIPTION
## Description
Speed up bulk ensembles endpoint

was fetching way too much stuff that wasnt even used by the FE
Fetch a more targeted ensemble on the detail page
restrict fields on list page


## Which app(s)/packages is this PR for?

=== Apps ===
- [x] Backend
- [ ] Musescore Headless
- [x] Frontend

=== Packages ===
- [ ] Part Formatter
- [ ] Score Diff
- [ ] Scoreforge


Optional:
Shortcut ticket link: