### PR TITLE
[FEAT] Part Name Matrix Merger

### DIFF
--- a/apps/backend/ensembles/lib/part_name_matrix.py
+++ b/apps/backend/ensembles/lib/part_name_matrix.py
@@ -1,0 +1,81 @@
+from collections import defaultdict
+from itertools import combinations
+
+from django.db.models import Value, IntegerField
+from django.db.models.functions import Coalesce
+
+from ensembles.models import PartAsset, PartName
+
+
+def build_part_name_matrix(ensemble):
+    """
+    Build arrangement × part-name matrix data for the ensemble editor UI.
+    Uses latest arrangement versions only; excludes score PDFs.
+    """
+    from django.db.models.expressions import RawSQL
+
+    arrangements = list(
+        ensemble.arrangements.annotate(
+            first_num=RawSQL(
+                "CAST((regexp_matches(mvt_no, '^([0-9]+)'))[1] AS INTEGER)",
+                [],
+            ),
+            second_num=RawSQL(
+                "CAST((regexp_matches(mvt_no, '^[0-9]+(?:-|m)([0-9]+)'))[1] AS INTEGER)",
+                [],
+            ),
+        ).order_by("first_num", "second_num", "mvt_no", "id")
+    )
+
+    columns = list(
+        PartName.objects.filter(ensemble=ensemble).order_by(
+            Coalesce("order", Value(999999, output_field=IntegerField())), "id"
+        )
+    )
+
+    part_assets = (
+        PartAsset.objects.filter(
+            arrangement_version__arrangement__ensemble=ensemble,
+            arrangement_version__is_latest=True,
+            is_score=False,
+        )
+        .select_related("arrangement_version__arrangement")
+    )
+
+    cells = []
+    part_names_by_version = defaultdict(set)
+
+    for asset in part_assets:
+        arrangement_id = asset.arrangement_version.arrangement_id
+        cells.append(
+            {
+                "arrangement_id": arrangement_id,
+                "part_name_id": asset.part_name_id,
+                "part_asset_id": asset.id,
+            }
+        )
+        part_names_by_version[asset.arrangement_version_id].add(asset.part_name_id)
+
+    merge_conflicts = []
+    seen_pairs = set()
+    for part_name_ids in part_names_by_version.values():
+        unique_ids = sorted(part_name_ids)
+        if len(unique_ids) < 2:
+            continue
+        for id_a, id_b in combinations(unique_ids, 2):
+            pair = (id_a, id_b)
+            if pair not in seen_pairs:
+                seen_pairs.add(pair)
+                merge_conflicts.append([id_a, id_b])
+
+    return {
+        "arrangements": [
+            {"id": a.id, "title": a.title, "mvt_no": a.mvt_no} for a in arrangements
+        ],
+        "columns": [
+            {"id": c.id, "display_name": c.display_name, "order": c.order}
+            for c in columns
+        ],
+        "cells": cells,
+        "merge_conflicts": merge_conflicts,
+    }

--- a/apps/backend/ensembles/models/part.py
+++ b/apps/backend/ensembles/models/part.py
@@ -139,6 +139,58 @@ class PartName(models.Model):
         )
         second.delete()
 
+    def _persist_display_name_change_aliases(self, previous_display_name: str) -> None:
+        """Record aliases so re-uploads still resolve the old label to this PartName."""
+        from ensembles.models.part_name_alias import PartNameAlias
+
+        arrangements_with_part = set(
+            PartAsset.objects.filter(part_name=self).values_list(
+                "arrangement_version__arrangement_id", flat=True
+            )
+        )
+        arrangements_with_part.discard(None)
+        for arr_id in arrangements_with_part:
+            PartNameAlias.objects.update_or_create(
+                ensemble_id=self.ensemble_id,
+                arrangement_id=arr_id,
+                alias_normalized=PartNameAlias.normalize(previous_display_name),
+                defaults={
+                    "alias": previous_display_name,
+                    "canonical_part_name": self,
+                },
+            )
+
+    def rename_display_name(self, new_display_name: str) -> "PartName":
+        new_display_name = (new_display_name or "").strip()
+        if not new_display_name:
+            raise ValidationError("Display name cannot be empty.")
+
+        from ensembles.models.part_name_alias import PartNameAlias
+
+        if (
+            PartName.objects.filter(
+                ensemble_id=self.ensemble_id, display_name__iexact=new_display_name
+            )
+            .exclude(pk=self.pk)
+            .exists()
+        ):
+            raise ValidationError(
+                "A part name with this display name already exists in this ensemble."
+            )
+
+        previous_display_name = self.display_name
+        if PartNameAlias.normalize(previous_display_name) == PartNameAlias.normalize(
+            new_display_name
+        ):
+            return self
+
+        with transaction.atomic():
+            self._persist_display_name_change_aliases(previous_display_name)
+            self.display_name = new_display_name
+            self.save(update_fields=["display_name"])
+
+        return self
+
     @staticmethod
     def normalize_display_name(value: str) -> str:
         # Normalize for stable matching (case/whitespace-insensitive).
@@ -254,29 +306,13 @@ class PartName(models.Model):
                     },
                 )
 
-            # If we are renaming the canonical display name, keep the old canonical name
-            # as an alias too for arrangements that had the target part.
-            if new_displayname and PartNameAlias.normalize(previous_target_name) != PartNameAlias.normalize(new_displayname):
-                arrangements_with_target = set(
-                    PartAsset.objects.filter(part_name=target)
-                    .values_list("arrangement_version__arrangement_id", flat=True)
-                )
-                arrangements_with_target.discard(None)
-                for arr_id in arrangements_with_target:
-                    PartNameAlias.objects.update_or_create(
-                        ensemble_id=ensemble_id,
-                        arrangement_id=arr_id,
-                        alias_normalized=PartNameAlias.normalize(previous_target_name),
-                        defaults={
-                            "alias": previous_target_name,
-                            "canonical_part_name": target,
-                        },
-                    )
-
             # Merge actual PartAsset references and delete the redundant PartName.
             target._merge_objs(merge_from)
 
-            if new_displayname:
+            if new_displayname and PartNameAlias.normalize(previous_target_name) != PartNameAlias.normalize(
+                new_displayname
+            ):
+                target._persist_display_name_change_aliases(previous_target_name)
                 target.display_name = new_displayname
                 target.save(update_fields=["display_name"])
 

--- a/apps/backend/ensembles/serializers/__init__.py
+++ b/apps/backend/ensembles/serializers/__init__.py
@@ -234,12 +234,14 @@ class EnsembleSerializer(serializers.ModelSerializer):
             part_name_ids = [part.id for part in parts]
 
             arrangement_titles_by_part_name_id = defaultdict(list)
+            arrangement_ids_by_part_name_id = defaultdict(list)
             if part_name_ids:
                 part_assets = (
                     PartAsset.objects.filter(
                         part_name_id__in=part_name_ids,
                         arrangement_version__arrangement__ensemble=obj,
                         arrangement_version__is_latest=True,
+                        is_score=False,
                     )
                     .select_related("arrangement_version__arrangement")
                     .order_by(
@@ -248,9 +250,9 @@ class EnsembleSerializer(serializers.ModelSerializer):
                     )
                 )
                 for asset in part_assets:
-                    arrangement_titles_by_part_name_id[asset.part_name_id].append(
-                        asset.arrangement_version.arrangement.title
-                    )
+                    arr = asset.arrangement_version.arrangement
+                    arrangement_titles_by_part_name_id[asset.part_name_id].append(arr.title)
+                    arrangement_ids_by_part_name_id[asset.part_name_id].append(arr.id)
 
             # Keep a stable, typed shape for the frontend
             return [
@@ -258,6 +260,7 @@ class EnsembleSerializer(serializers.ModelSerializer):
                     "id": part.id,
                     "display_name": part.display_name,
                     "arrangements": arrangement_titles_by_part_name_id.get(part.id, []),
+                    "arrangement_ids": arrangement_ids_by_part_name_id.get(part.id, []),
                     "order": part.order,
                 }
                 for part in parts
@@ -333,6 +336,21 @@ class EnsembleListSerializer(serializers.ModelSerializer):
         if annotated_count is not None:
             return annotated_count
         return obj.arrangements.count()
+
+
+class EnsemblePartNameRenameSerializer(serializers.Serializer):
+    part_name_id = serializers.IntegerField(required=True)
+    display_name = serializers.CharField(required=True, max_length=64)
+
+    def validate(self, attrs):
+        ensemble = self.context["ensemble"]
+        try:
+            part = PartName.objects.get(id=attrs["part_name_id"], ensemble=ensemble)
+        except PartName.DoesNotExist:
+            raise serializers.ValidationError({"part_name_id": "Invalid part name for this ensemble."})
+
+        attrs["part"] = part
+        return attrs
 
 
 class EnsemblePartNameMergeSerializer(serializers.Serializer):

--- a/apps/backend/ensembles/views/ensemble.py
+++ b/apps/backend/ensembles/views/ensemble.py
@@ -6,6 +6,7 @@ from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
+from ensembles.lib.part_name_matrix import build_part_name_matrix
 from ensembles.models import (
     Arrangement,
     ArrangementVersion,
@@ -18,6 +19,7 @@ from ensembles.serializers import (
     ArrangementSerializer,
     EnsembleListSerializer,
     EnsemblePartNameMergeSerializer,
+    EnsemblePartNameRenameSerializer,
     EnsembleSerializer,
 )
 from ensembles.tasks.part_books import generate_books_for_ensemble
@@ -205,9 +207,56 @@ class EnsembleViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_404_NOT_FOUND,
             )
 
+    @action(detail=True, methods=["get"], url_path="part-name-matrix")
+    def part_name_matrix(self, request, slug=None):
+        ensemble = self.get_object()
+        if not self._has_access(ensemble, request.user):
+            return Response(
+                {"detail": "You do not have access to this ensemble."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        return Response(build_part_name_matrix(ensemble))
+
+    @action(detail=True, methods=["post"], url_path="rename-part-name")
+    def rename_part_name(self, request, slug=None):
+        ensemble = self.get_object()
+        if not request.user.is_ensemble_admin(ensemble):
+            return Response(
+                {"detail": "Only ensemble admins can rename part names."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        serializer = EnsemblePartNameRenameSerializer(
+            data=request.data, context={"ensemble": ensemble}
+        )
+        serializer.is_valid(raise_exception=True)
+        part = serializer.validated_data["part"]
+        display_name = serializer.validated_data["display_name"]
+
+        from django.core.exceptions import ValidationError as DjangoValidationError
+
+        try:
+            part.rename_display_name(display_name)
+        except DjangoValidationError as e:
+            return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(
+            {"id": part.id, "display_name": part.display_name},
+            status=status.HTTP_200_OK,
+        )
+
     @action(detail=True, methods=["post"])
     def merge_part_names(self, request, slug=None):
-        serializer = EnsemblePartNameMergeSerializer(data=request.data, context={"ensemble": self.get_object()})
+        ensemble = self.get_object()
+        if not request.user.is_ensemble_admin(ensemble):
+            return Response(
+                {"detail": "Only ensemble admins can merge part names."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        serializer = EnsemblePartNameMergeSerializer(
+            data=request.data, context={"ensemble": ensemble}
+        )
         serializer.is_valid(raise_exception=True)
         validated_data = serializer.validated_data
 

--- a/apps/backend/ensembles/views_test.py
+++ b/apps/backend/ensembles/views_test.py
@@ -718,3 +718,173 @@ def test_part_names_with_null_order_sorted_last(ensemble, user, client):
     # Part with null order should come last
     assert part_names[2]["id"] == part3.id
     assert part_names[2]["order"] is None
+
+
+@pytest.mark.django_db
+def test_part_name_matrix(ensemble, user, client):
+    from ensembles.factories import PartAssetFactory, PartNameFactory
+    from ensembles.models import PartName
+
+    ensemble.owner = user
+    ensemble.save()
+
+    arr = ArrangementFactory(ensemble=ensemble, title="Movement 1", mvt_no="1")
+    v_latest = ArrangementVersionFactory(arrangement=arr, is_latest=True)
+    ArrangementVersionFactory(arrangement=arr, is_latest=False)
+
+    flute = PartNameFactory(ensemble=ensemble, display_name="Flute", order=0)
+    score_name = PartNameFactory(ensemble=ensemble, display_name="Score", order=1)
+    PartAssetFactory(arrangement_version=v_latest, part_name=flute, is_score=False)
+    PartAssetFactory(arrangement_version=v_latest, part_name=score_name, is_score=True)
+
+    url = reverse("ensembles:ensemble-part-name-matrix", kwargs={"slug": ensemble.slug})
+    r = client.get(url)
+    assert r.status_code == 200, r.content
+    data = r.json()
+
+    assert len(data["arrangements"]) == 1
+    assert data["arrangements"][0]["id"] == arr.id
+    assert len(data["columns"]) == 2
+    assert len(data["cells"]) == 1
+    assert data["cells"][0]["part_name_id"] == flute.id
+    assert data["cells"][0]["arrangement_id"] == arr.id
+
+
+@pytest.mark.django_db
+def test_part_name_matrix_merge_conflicts(ensemble, user, client):
+    from ensembles.factories import PartAssetFactory, PartNameFactory
+
+    ensemble.owner = user
+    ensemble.save()
+
+    arr = ArrangementFactory(ensemble=ensemble, mvt_no="1")
+    v = ArrangementVersionFactory(arrangement=arr, is_latest=True)
+    name1, name2 = PartNameFactory.create_batch(2, ensemble=ensemble)
+    PartAssetFactory(arrangement_version=v, part_name=name1)
+    PartAssetFactory(arrangement_version=v, part_name=name2)
+
+    url = reverse("ensembles:ensemble-part-name-matrix", kwargs={"slug": ensemble.slug})
+    r = client.get(url)
+    assert r.status_code == 200
+    conflicts = r.json()["merge_conflicts"]
+    assert [name1.id, name2.id] in conflicts or [name2.id, name1.id] in conflicts
+
+
+@pytest.mark.django_db
+def test_part_name_matrix_empty_ensemble(ensemble, user, client):
+    ensemble.owner = user
+    ensemble.save()
+
+    url = reverse("ensembles:ensemble-part-name-matrix", kwargs={"slug": ensemble.slug})
+    r = client.get(url)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["arrangements"] == []
+    assert data["cells"] == []
+
+
+@pytest.mark.django_db
+def test_rename_part_name_as_admin(ensemble, user, client):
+    from ensembles.factories import PartAssetFactory, PartNameFactory
+    from ensembles.models.part_name_alias import PartNameAlias
+
+    ensemble.owner = user
+    ensemble.save()
+
+    arr = ArrangementFactory(ensemble=ensemble)
+    v = ArrangementVersionFactory(arrangement=arr, is_latest=True)
+    part = PartNameFactory(ensemble=ensemble, display_name="Flute 1")
+    PartAssetFactory(arrangement_version=v, part_name=part)
+
+    url = reverse("ensembles:ensemble-rename-part-name", kwargs={"slug": ensemble.slug})
+    r = client.post(
+        url,
+        data={"part_name_id": part.id, "display_name": "Flute"},
+        content_type="application/json",
+    )
+    assert r.status_code == 200, r.content
+    part.refresh_from_db()
+    assert part.display_name == "Flute"
+    assert PartNameAlias.objects.filter(
+        ensemble=ensemble,
+        arrangement=arr,
+        alias_normalized=PartNameAlias.normalize("Flute 1"),
+        canonical_part_name=part,
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_rename_part_name_duplicate_rejected(ensemble, user, client):
+    from ensembles.models import PartName
+
+    ensemble.owner = user
+    ensemble.save()
+
+    part1 = PartName.objects.create(ensemble=ensemble, display_name="Flute")
+    part2 = PartName.objects.create(ensemble=ensemble, display_name="Clarinet")
+
+    url = reverse("ensembles:ensemble-rename-part-name", kwargs={"slug": ensemble.slug})
+    r = client.post(
+        url,
+        data={"part_name_id": part2.id, "display_name": "Flute"},
+        content_type="application/json",
+    )
+    assert r.status_code == 400
+
+
+@pytest.mark.django_db
+def test_rename_part_name_as_non_admin(ensemble, user, client):
+    from ensembles.models import PartName, EnsembleUsership
+
+    part = PartName.objects.create(ensemble=ensemble, display_name="Flute")
+    non_admin = UserFactory()
+    EnsembleUsership.objects.create(ensemble=ensemble, user=non_admin)
+
+    url = reverse("ensembles:ensemble-rename-part-name", kwargs={"slug": ensemble.slug})
+    client.force_login(non_admin)
+    r = client.post(
+        url,
+        data={"part_name_id": part.id, "display_name": "Flute I"},
+        content_type="application/json",
+    )
+    assert r.status_code == 403
+
+
+@pytest.mark.django_db
+def test_merge_part_names_as_non_admin(ensemble, user, client):
+    from ensembles.models import PartName, EnsembleUsership
+
+    part1 = PartName.objects.create(ensemble=ensemble, display_name="Flute")
+    part2 = PartName.objects.create(ensemble=ensemble, display_name="Flute I")
+    non_admin = UserFactory()
+    EnsembleUsership.objects.create(ensemble=ensemble, user=non_admin)
+
+    url = reverse("ensembles:ensemble-merge-part-names", kwargs={"slug": ensemble.slug})
+    client.force_login(non_admin)
+    r = client.post(
+        url,
+        data={"first_id": part1.id, "second_id": part2.id},
+        content_type="application/json",
+    )
+    assert r.status_code == 403
+
+
+@pytest.mark.django_db
+def test_part_names_include_arrangement_ids(ensemble, user, client):
+    from ensembles.factories import PartAssetFactory, PartNameFactory
+
+    ensemble.owner = user
+    ensemble.save()
+
+    arr = ArrangementFactory(ensemble=ensemble, title="Song A")
+    v = ArrangementVersionFactory(arrangement=arr, is_latest=True)
+    part = PartNameFactory(ensemble=ensemble, display_name="Flute")
+    PartAssetFactory(arrangement_version=v, part_name=part)
+
+    url = reverse("ensembles:ensemble-detail", kwargs={"slug": ensemble.slug})
+    r = client.get(url)
+    assert r.status_code == 200
+    part_names = r.json()["part_names"]
+    flute_entry = next(p for p in part_names if p["id"] == part.id)
+    assert flute_entry["arrangement_ids"] == [arr.id]
+    assert flute_entry["arrangements"] == ["Song A"]

--- a/apps/frontend/src/api/ensembles.ts
+++ b/apps/frontend/src/api/ensembles.ts
@@ -207,6 +207,51 @@ export const ensembleApi = {
     return response.json();
   },
 
+  async getPartNameMatrix(ensembleSlug: string) {
+    const response = await fetch(
+      `${API_BASE_URL}/ensembles/${ensembleSlug}/part-name-matrix/`,
+      { credentials: "include" }
+    );
+    if (!response.ok) {
+      let errorDetails = "";
+      try {
+        const errorData = await response.json();
+        errorDetails = errorData.detail || JSON.stringify(errorData);
+      } catch {
+        errorDetails = await response.text();
+      }
+      throw new Error(
+        `Failed to fetch part name matrix (status: ${response.status}) - ${errorDetails}`
+      );
+    }
+    return response.json();
+  },
+
+  async renamePartName(ensembleSlug: string, partNameId: number, displayName: string) {
+    const response = await fetch(
+      `${API_BASE_URL}/ensembles/${ensembleSlug}/rename-part-name/`,
+      {
+        method: "POST",
+        headers: getHeadersWithCsrf(),
+        body: JSON.stringify({ part_name_id: partNameId, display_name: displayName }),
+        credentials: "include",
+      }
+    );
+    if (!response.ok) {
+      let errorDetails = "";
+      try {
+        const errorData = await response.json();
+        errorDetails = errorData.detail || JSON.stringify(errorData);
+      } catch {
+        errorDetails = await response.text();
+      }
+      throw new Error(
+        `Failed to rename part name (status: ${response.status}) - ${errorDetails}`
+      );
+    }
+    return response.json();
+  },
+
   async mergePartNames(
     ensembleSlug: string,
     firstId: number,

--- a/apps/frontend/src/api/types.ts
+++ b/apps/frontend/src/api/types.ts
@@ -108,6 +108,32 @@ export interface PartName {
   display_name: string;
   order: number | null;
   arrangements?: string[];
+  arrangement_ids?: number[];
+}
+
+export interface PartNameMatrixArrangement {
+  id: number;
+  title: string;
+  mvt_no: string;
+}
+
+export interface PartNameMatrixColumn {
+  id: number;
+  display_name: string;
+  order: number | null;
+}
+
+export interface PartNameMatrixCell {
+  arrangement_id: number;
+  part_name_id: number;
+  part_asset_id: number;
+}
+
+export interface PartNameMatrix {
+  arrangements: PartNameMatrixArrangement[];
+  columns: PartNameMatrixColumn[];
+  cells: PartNameMatrixCell[];
+  merge_conflicts: [number, number][];
 }
 
 export interface Ensemble {

--- a/apps/frontend/src/pages/ensembles/EnsembleDetailPage.tsx
+++ b/apps/frontend/src/pages/ensembles/EnsembleDetailPage.tsx
@@ -26,19 +26,15 @@ import {
 import { 
   IconAlertCircle, 
   IconTrash,
-  IconBook,
-  IconDownload,
-  IconRefresh,
-  IconChevronDown,
-  IconChevronRight,
-  IconGripVertical,
 } from '@tabler/icons-react';
 import { apiService } from '../../services/apiService';
 import { useParams, Link } from 'react-router-dom';
 import { usePageTitle } from '../../context/usePageTitle';
 
-import type { Ensemble, PartName, EnsemblePartBook } from '../../services/apiService';
+import type { Ensemble, PartName } from '../../services/apiService';
 import { ScoreTitlePreview, type PreviewStyleName } from '../../components/ScoreTitlePreview';
+import { PartNameMatrixEditor } from './PartNameMatrixEditor';
+import { EnsemblePartBooksSection } from './EnsemblePartBooksSection';
 
 type LegacyPartNameMap = Record<string, string>;
 type EnsembleWithPartNames = Ensemble & {
@@ -63,15 +59,7 @@ export default function EnsembleDisplay() {
 
   const [confirmRemoveOpen, setConfirmRemoveOpen] = useState(false);
   const [removeCandidate, setRemoveCandidate] = useState<{ id: number; username: string } | null>(null);
-
-  const [mergeModalOpen, setMergeModalOpen] = useState(false);
-  const [mergeFirstId, setMergeFirstId] = useState<string | null>(null);
-  const [mergeSecondId, setMergeSecondId] = useState<string | null>(null);
-  const [mergeNewDisplayName, setMergeNewDisplayName] = useState<string>('');
-  const [expandedPartId, setExpandedPartId] = useState<number | null>(null);
-  const [reorderingParts, setReorderingParts] = useState(false);
-  const [draggedPartId, setDraggedPartId] = useState<number | null>(null);
-  const [dragOverPartId, setDragOverPartId] = useState<number | null>(null);
+  const [activeTab, setActiveTab] = useState<string | null>('overview');
 
   // helper to read CSRF token from cookies (same logic as apiService)
   function getCsrfToken(): string | null {
@@ -268,55 +256,11 @@ export default function EnsembleDisplay() {
       .filter(Boolean) as PartName[];
   })();
 
-  const partNameSelectData = partNames
-    .slice()
-    .sort((a, b) => a.display_name.localeCompare(b.display_name))
-    .map((p) => ({ value: String(p.id), label: p.display_name }));
-
-  const handleGeneratePartBooks = async () => {
-    if (!ensemble) return;
-    try {
-      setError(null);
-      await apiService.generatePartBooksForEnsemble(ensemble.slug);
-      await fetchEnsemble(ensemble.slug);
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : String(err));
-    }
-  };
-
-  const handleMergePartNames = async () => {
-    if (!ensemble) return;
-    const firstId = Number(mergeFirstId);
-    const secondId = Number(mergeSecondId);
-    if (!Number.isFinite(firstId) || !Number.isFinite(secondId) || firstId === secondId) {
-      setError('Please select two different part names to merge.');
-      return;
-    }
-
-    try {
-      setSaving(true);
-      setError(null);
-      await apiService.mergePartNames(
-        ensemble.slug,
-        firstId,
-        secondId,
-        mergeNewDisplayName.trim() ? mergeNewDisplayName.trim() : null
-      );
-      await fetchEnsemble(ensemble.slug);
-      setMergeModalOpen(false);
-      setMergeFirstId(null);
-      setMergeSecondId(null);
-      setMergeNewDisplayName('');
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setSaving(false);
-    }
-  };
+  const isPartsTab = activeTab === 'parts';
 
   return (
-    <Container size="md" py="xl">
-      <Paper shadow="sm" p="xl" radius="md">
+    <Container fluid={isPartsTab} size={isPartsTab ? undefined : 'md'} py="xl">
+      <Paper shadow="sm" p={isPartsTab ? 'lg' : 'xl'} radius="md">
         <Group align="center" mb="md">
           <Group align="center">
             <Title order={2}>{ensemble.name}</Title>
@@ -355,10 +299,11 @@ export default function EnsembleDisplay() {
           </Card>
         </Collapse>
 
-        <Tabs defaultValue="overview" mt="md">
+        <Tabs value={activeTab} onChange={setActiveTab} mt="md">
           <Tabs.List>
             <Tabs.Tab value="overview">Overview</Tabs.Tab>
-            <Tabs.Tab value="parts">Parts & part books</Tabs.Tab>
+            <Tabs.Tab value="parts">Parts</Tabs.Tab>
+            <Tabs.Tab value="part-books">Part books</Tabs.Tab>
           </Tabs.List>
 
           <Tabs.Panel value="overview" pt="md">
@@ -463,277 +408,31 @@ export default function EnsembleDisplay() {
           </Tabs.Panel>
 
           <Tabs.Panel value="parts" pt="md">
-            <Card withBorder>
-              <Group mb="xs" justify="space-between">
-                <Group gap="xs">
-                  <IconBook size={18} />
-                  <Text fw={500}>Parts & part books</Text>
-                  <Badge size="sm" variant="light">{partNames.length} parts</Badge>
-                  {ensemble.part_books_generating && (
-                    <Badge color="blue" variant="light" leftSection={<Loader size={12} />}>
-                      Generating…
-                    </Badge>
-                  )}
-                </Group>
-                {isAdmin && (
-                  <Group gap="xs">
-                    <Button
-                      size="xs"
-                      variant="outline"
-                      onClick={() => setMergeModalOpen(true)}
-                      disabled={partNames.length < 2}
-                    >
-                      Merge part names
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="filled"
-                      leftSection={<IconRefresh size={14} />}
-                      onClick={handleGeneratePartBooks}
-                      disabled={!!ensemble.part_books_generating || partNames.length === 0}
-                    >
-                      Generate part books
-                    </Button>
-                  </Group>
-                )}
-              </Group>
-              <Divider />
-              <div style={{ maxHeight: 480, overflowY: 'auto' }}>
-                {partNames.length === 0 ? (
-                  <Text mt="md" size="sm" c="dimmed">
-                    No part names yet. Part names are added when you upload arrangement versions with parts.
-                  </Text>
-                ) : (
-                  <Stack mt="md" gap={0}>
-                    {partNames
-                      .slice()
-                      .sort((a, b) => {
-                        // Sort by order (nulls last), then by display_name for stable ordering
-                        if (a.order !== null && b.order !== null) {
-                          return a.order - b.order;
-                        }
-                        if (a.order !== null) return -1;
-                        if (b.order !== null) return 1;
-                        return a.display_name.localeCompare(b.display_name);
-                      })
-                      .map((part, index, sortedParts) => {
-                        const partBooks: EnsemblePartBook[] = (ensemble.part_books ?? [])
-                          .filter((b) => b.part_display_name === part.display_name)
-                          .sort((a, b) => b.revision - a.revision);
-                        const latestBook = partBooks[0];
-                        const olderBooks = partBooks.slice(1);
-                        const latestRev = ensemble.latest_part_book_revision ?? 0;
-                        const isExpanded = expandedPartId === part.id;
+            <Group gap="xs" mb="md">
+              <Text fw={600} size="lg">
+                Part names
+              </Text>
+              <Badge size="sm" variant="light">
+                {partNames.length} parts
+              </Badge>
+            </Group>
+            <Text size="sm" c="dimmed" mb="md">
+              Map and merge part names across arrangements. Drag a part onto a base column to link them for merging.
+            </Text>
+            <PartNameMatrixEditor
+              ensembleSlug={slug}
+              isAdmin={isAdmin}
+              onSaved={() => fetchEnsemble(slug)}
+            />
+          </Tabs.Panel>
 
-                        const isDragging = draggedPartId === part.id;
-                        const isDragOver = dragOverPartId === part.id;
-
-                        const handleDragStart = (e: React.DragEvent) => {
-                          if (!ensemble?.is_admin) return;
-                          setDraggedPartId(part.id);
-                          e.dataTransfer.effectAllowed = 'move';
-                          e.dataTransfer.setData('text/plain', part.id.toString());
-                          // Make the dragged element semi-transparent
-                          if (e.currentTarget instanceof HTMLElement) {
-                            e.currentTarget.style.opacity = '0.5';
-                          }
-                        };
-
-                        const handleDragEnd = (e: React.DragEvent) => {
-                          setDraggedPartId(null);
-                          setDragOverPartId(null);
-                          // Reset opacity
-                          if (e.currentTarget instanceof HTMLElement) {
-                            e.currentTarget.style.opacity = '1';
-                          }
-                        };
-
-                        const handleDragOver = (e: React.DragEvent) => {
-                          if (!ensemble?.is_admin || draggedPartId === part.id) return;
-                          e.preventDefault();
-                          e.dataTransfer.dropEffect = 'move';
-                          setDragOverPartId(part.id);
-                        };
-
-                        const handleDragLeave = () => {
-                          setDragOverPartId(null);
-                        };
-
-                        const handleDrop = async (e: React.DragEvent) => {
-                          e.preventDefault();
-                          if (!ensemble?.is_admin || draggedPartId === null || draggedPartId === part.id) {
-                            setDragOverPartId(null);
-                            return;
-                          }
-
-                          const draggedIndex = sortedParts.findIndex(p => p.id === draggedPartId);
-                          const targetIndex = index;
-
-                          if (draggedIndex === -1 || draggedIndex === targetIndex) {
-                            setDragOverPartId(null);
-                            return;
-                          }
-
-                          // Create new order array
-                          const reorderedParts = [...sortedParts];
-                          const [draggedPart] = reorderedParts.splice(draggedIndex, 1);
-                          reorderedParts.splice(targetIndex, 0, draggedPart);
-
-                          // Update orders based on new positions
-                          const updatedParts = reorderedParts.map((p, i) => ({
-                            ...p,
-                            order: i
-                          }));
-
-                          try {
-                            setReorderingParts(true);
-                            await apiService.updatePartOrder(
-                              slug,
-                              updatedParts.map(p => ({ id: p.id, order: p.order ?? 0 }))
-                            );
-                            // Refresh ensemble data
-                            const updated = await apiService.getEnsemble(slug);
-                            setEnsemble(updated);
-                          } catch (err) {
-                            console.error('Failed to update part order:', err);
-                            alert('Failed to update part order. Please try again.');
-                          } finally {
-                            setReorderingParts(false);
-                            setDragOverPartId(null);
-                            setDraggedPartId(null);
-                          }
-                        };
-
-                        return (
-                          <div key={part.id}>
-                            <Card 
-                              withBorder 
-                              radius="sm" 
-                              p="sm" 
-                              mb="xs"
-                              draggable={ensemble?.is_admin && !reorderingParts}
-                              onDragStart={handleDragStart}
-                              onDragEnd={handleDragEnd}
-                              onDragOver={handleDragOver}
-                              onDragLeave={handleDragLeave}
-                              onDrop={handleDrop}
-                              style={{
-                                cursor: ensemble?.is_admin ? (isDragging ? 'grabbing' : 'grab') : 'default',
-                                opacity: isDragging ? 0.5 : 1,
-                                borderColor: isDragOver ? 'var(--mantine-color-blue-6)' : undefined,
-                                borderWidth: isDragOver ? 2 : undefined,
-                                backgroundColor: isDragOver ? 'var(--mantine-color-blue-0)' : undefined,
-                                transition: 'background-color 0.2s, border-color 0.2s',
-                              }}
-                            >
-                              <Group justify="space-between" wrap="nowrap">
-                                <Group gap="xs" style={{ minWidth: 0 }}>
-                                  {ensemble?.is_admin && (
-                                    <ActionIcon
-                                      variant="subtle"
-                                      size="sm"
-                                      style={{ cursor: 'grab' }}
-                                      title="Drag to reorder"
-                                      onMouseDown={(e) => e.stopPropagation()}
-                                      onClick={(e) => e.stopPropagation()}
-                                    >
-                                      <IconGripVertical size={16} />
-                                    </ActionIcon>
-                                  )}
-                                  <ActionIcon
-                                    variant="subtle"
-                                    size="sm"
-                                    onClick={() => setExpandedPartId(isExpanded ? null : part.id)}
-                                    disabled={olderBooks.length === 0}
-                                    title={olderBooks.length ? 'Older revisions' : undefined}
-                                  >
-                                    {olderBooks.length > 0 ? (
-                                      isExpanded ? <IconChevronDown size={16} /> : <IconChevronRight size={16} />
-                                    ) : (
-                                      <IconChevronRight size={16} style={{ opacity: 0.3 }} />
-                                    )}
-                                  </ActionIcon>
-                                  <Text size="sm" fw={600}>{part.display_name}</Text>
-                                  {latestBook && (
-                                    <>
-                                      <Badge size="xs" variant="light" color={latestBook.revision === latestRev ? 'teal' : 'gray'}>
-                                        r{latestBook.revision} {latestBook.revision === latestRev ? '(latest)' : ''}
-                                      </Badge>
-                                      {!latestBook.is_rendered && (
-                                        <Badge size="xs" variant="light" color="yellow">Rendering…</Badge>
-                                      )}
-                                    </>
-                                  )}
-                                  {!latestBook && (
-                                    <Text size="xs" c="dimmed">No part book</Text>
-                                  )}
-                                </Group>
-                                <Group>
-                                  {(part.arrangements) && (length <= 2)  && (
-                                    <>
-                                      {part.arrangements.map((arr) => ( 
-                                        <Text size="xs" c="dimmed">{arr} </Text>
-                                      ))}
-                                    </>
-                                  )}
-                                  {(part.arrangements) && (length >2) && (
-                                    <>
-                                      <Text size="xs" c="dimmed">{part.arrangements[0]}</Text>
-                                      <Text size="xs" c="dimmed">... {part.arrangements.length - 1} more</Text>
-                                    {part.arrangements.map((arr) => ( <Text size="xs" c="dimmed">{arr}</Text> ))}
-                                    </>
-                                  )}
-                                </Group>
-                                {latestBook?.is_rendered && latestBook.download_url && (
-                                  <Button
-                                    component="a"
-                                    href={latestBook.download_url}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    size="xs"
-                                    variant="light"
-                                    leftSection={<IconDownload size={14} />}
-                                  >
-                                    Download
-                                  </Button>
-                                )}
-                              </Group>
-                              <Collapse in={isExpanded && olderBooks.length > 0}>
-                                <Stack gap="xs" mt="sm" pl="md" style={{ borderLeft: '2px solid var(--mantine-color-default-border)' }}>
-                                  <Text size="xs" c="dimmed" fw={500}>Older revisions</Text>
-                                  {olderBooks.map((book) => (
-                                    <Group key={book.id} justify="space-between">
-                                      <Group gap="xs">
-                                        <Text size="sm">Revision {book.revision}</Text>
-                                        {!book.is_rendered && (
-                                          <Badge size="xs" variant="light" color="yellow">Rendering…</Badge>
-                                        )}
-                                      </Group>
-                                      {book.is_rendered && book.download_url && (
-                                        <Button
-                                          component="a"
-                                          href={book.download_url}
-                                          target="_blank"
-                                          rel="noopener noreferrer"
-                                          size="xs"
-                                          variant="subtle"
-                                          leftSection={<IconDownload size={12} />}
-                                        >
-                                          Download
-                                        </Button>
-                                      )}
-                                    </Group>
-                                  ))}
-                                </Stack>
-                              </Collapse>
-                            </Card>
-                          </div>
-                        );
-                      })}
-                  </Stack>
-                )}
-              </div>
-            </Card>
+          <Tabs.Panel value="part-books" pt="md">
+            <EnsemblePartBooksSection
+              ensemble={ensemble}
+              partNames={partNames}
+              onRefresh={() => fetchEnsemble(slug)}
+              onError={(message) => setError(message)}
+            />
           </Tabs.Panel>
         </Tabs>
       </Paper>
@@ -746,48 +445,6 @@ export default function EnsembleDisplay() {
         </Group>
       </Modal>
 
-      <Modal
-        opened={mergeModalOpen}
-        onClose={() => setMergeModalOpen(false)}
-        title="Merge part names"
-      >
-        <Stack>
-          <Select
-            label="Keep"
-            placeholder="Choose the part name to keep"
-            data={partNameSelectData}
-            value={mergeFirstId}
-            onChange={setMergeFirstId}
-            searchable
-          />
-          <Select
-            label="Merge into it"
-            placeholder="Choose the part name to merge"
-            data={partNameSelectData}
-            value={mergeSecondId}
-            onChange={setMergeSecondId}
-            searchable
-          />
-          <TextInput
-            label="New display name (optional)"
-            placeholder="Leave blank to keep the chosen name"
-            value={mergeNewDisplayName}
-            onChange={(e) => setMergeNewDisplayName(e.currentTarget.value)}
-          />
-          <Group justify="flex-end">
-            <Button variant="outline" onClick={() => setMergeModalOpen(false)}>
-              Cancel
-            </Button>
-            <Button
-              onClick={handleMergePartNames}
-              loading={saving}
-              disabled={!mergeFirstId || !mergeSecondId}
-            >
-              Merge
-            </Button>
-          </Group>
-        </Stack>
-      </Modal>
     </Container>
   );
 }

--- a/apps/frontend/src/pages/ensembles/EnsemblePartBooksSection.tsx
+++ b/apps/frontend/src/pages/ensembles/EnsemblePartBooksSection.tsx
@@ -1,0 +1,331 @@
+import { useState } from "react";
+import {
+  ActionIcon,
+  Badge,
+  Button,
+  Card,
+  Collapse,
+  Divider,
+  Group,
+  Loader,
+  Stack,
+  Text,
+} from "@mantine/core";
+import {
+  IconBook,
+  IconChevronDown,
+  IconChevronRight,
+  IconDownload,
+  IconGripVertical,
+  IconRefresh,
+} from "@tabler/icons-react";
+import { apiService } from "../../services/apiService";
+import type { Ensemble, EnsemblePartBook, PartName } from "../../services/apiService";
+
+type Props = {
+  ensemble: Ensemble;
+  partNames: PartName[];
+  onRefresh: () => void;
+  onError: (message: string) => void;
+};
+
+export function EnsemblePartBooksSection({
+  ensemble,
+  partNames,
+  onRefresh,
+  onError,
+}: Props) {
+  const [expandedPartId, setExpandedPartId] = useState<number | null>(null);
+  const [reorderingParts, setReorderingParts] = useState(false);
+  const [draggedPartId, setDraggedPartId] = useState<number | null>(null);
+  const [dragOverPartId, setDragOverPartId] = useState<number | null>(null);
+  const [generating, setGenerating] = useState(false);
+
+  const isAdmin = ensemble.is_admin;
+  const latestRev = ensemble.latest_part_book_revision ?? 0;
+
+  const handleGeneratePartBooks = async () => {
+    try {
+      setGenerating(true);
+      await apiService.generatePartBooksForEnsemble(ensemble.slug);
+      onRefresh();
+    } catch (err: unknown) {
+      onError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  const sortedParts = partNames
+    .slice()
+    .sort((a, b) => {
+      if (a.order !== null && b.order !== null) return a.order - b.order;
+      if (a.order !== null) return -1;
+      if (b.order !== null) return 1;
+      return a.display_name.localeCompare(b.display_name);
+    });
+
+  return (
+    <Card withBorder radius="md" p="lg">
+      <Group mb="md" justify="space-between">
+        <Group gap="xs">
+          <IconBook size={20} />
+          <Text fw={600} size="lg">
+            Part books
+          </Text>
+          <Badge size="sm" variant="light">
+            {partNames.length} parts
+          </Badge>
+          {ensemble.part_books_generating && (
+            <Badge color="blue" variant="light" leftSection={<Loader size={12} />}>
+              Generating…
+            </Badge>
+          )}
+        </Group>
+        {isAdmin && (
+          <Button
+            size="sm"
+            variant="filled"
+            leftSection={<IconRefresh size={14} />}
+            onClick={handleGeneratePartBooks}
+            loading={generating}
+            disabled={!!ensemble.part_books_generating || partNames.length === 0}
+          >
+            Generate part books
+          </Button>
+        )}
+      </Group>
+      <Text size="sm" c="dimmed" mb="md">
+        Compiled PDFs per part across all arrangements. Drag to reorder how parts appear in exports.
+      </Text>
+      <Divider mb="md" />
+
+      {partNames.length === 0 ? (
+        <Text size="sm" c="dimmed">
+          No part books yet. Add part names above, then generate.
+        </Text>
+      ) : (
+        <div style={{ maxHeight: 480, overflowY: "auto" }}>
+          <Stack gap={0}>
+            {sortedParts.map((part, index, sortedPartsList) => {
+              const partBooks: EnsemblePartBook[] = (ensemble.part_books ?? [])
+                .filter((b) => b.part_display_name === part.display_name)
+                .sort((a, b) => b.revision - a.revision);
+              const latestBook = partBooks[0];
+              const olderBooks = partBooks.slice(1);
+              const isExpanded = expandedPartId === part.id;
+              const isDragging = draggedPartId === part.id;
+              const isDragOver = dragOverPartId === part.id;
+
+              const handleDragStart = (e: React.DragEvent) => {
+                if (!isAdmin) return;
+                setDraggedPartId(part.id);
+                e.dataTransfer.effectAllowed = "move";
+                e.dataTransfer.setData("text/plain", part.id.toString());
+                if (e.currentTarget instanceof HTMLElement) {
+                  e.currentTarget.style.opacity = "0.5";
+                }
+              };
+
+              const handleDragEnd = (e: React.DragEvent) => {
+                setDraggedPartId(null);
+                setDragOverPartId(null);
+                if (e.currentTarget instanceof HTMLElement) {
+                  e.currentTarget.style.opacity = "1";
+                }
+              };
+
+              const handleDragOver = (e: React.DragEvent) => {
+                if (!isAdmin || draggedPartId === part.id) return;
+                e.preventDefault();
+                e.dataTransfer.dropEffect = "move";
+                setDragOverPartId(part.id);
+              };
+
+              const handleDragLeave = () => setDragOverPartId(null);
+
+              const handleDrop = async (e: React.DragEvent) => {
+                e.preventDefault();
+                if (!isAdmin || draggedPartId === null || draggedPartId === part.id) {
+                  setDragOverPartId(null);
+                  return;
+                }
+
+                const draggedIndex = sortedPartsList.findIndex((p) => p.id === draggedPartId);
+                const targetIndex = index;
+                if (draggedIndex === -1 || draggedIndex === targetIndex) {
+                  setDragOverPartId(null);
+                  return;
+                }
+
+                const reorderedParts = [...sortedPartsList];
+                const [draggedPart] = reorderedParts.splice(draggedIndex, 1);
+                reorderedParts.splice(targetIndex, 0, draggedPart);
+                const updatedParts = reorderedParts.map((p, i) => ({ ...p, order: i }));
+
+                try {
+                  setReorderingParts(true);
+                  await apiService.updatePartOrder(
+                    ensemble.slug,
+                    updatedParts.map((p) => ({ id: p.id, order: p.order ?? 0 }))
+                  );
+                  onRefresh();
+                } catch (err) {
+                  onError(
+                    err instanceof Error ? err.message : "Failed to update part order."
+                  );
+                } finally {
+                  setReorderingParts(false);
+                  setDragOverPartId(null);
+                  setDraggedPartId(null);
+                }
+              };
+
+              return (
+                <div key={part.id}>
+                  <Card
+                    withBorder
+                    radius="sm"
+                    p="sm"
+                    mb="xs"
+                    draggable={isAdmin && !reorderingParts}
+                    onDragStart={handleDragStart}
+                    onDragEnd={handleDragEnd}
+                    onDragOver={handleDragOver}
+                    onDragLeave={handleDragLeave}
+                    onDrop={handleDrop}
+                    style={{
+                      cursor: isAdmin ? (isDragging ? "grabbing" : "grab") : "default",
+                      opacity: isDragging ? 0.5 : 1,
+                      borderColor: isDragOver ? "var(--mantine-color-blue-6)" : undefined,
+                      borderWidth: isDragOver ? 2 : undefined,
+                      backgroundColor: isDragOver
+                        ? "var(--mantine-color-blue-0)"
+                        : undefined,
+                      transition: "background-color 0.2s, border-color 0.2s",
+                    }}
+                  >
+                    <Group justify="space-between" wrap="nowrap">
+                      <Group gap="xs" style={{ minWidth: 0 }}>
+                        {isAdmin && (
+                          <ActionIcon
+                            variant="subtle"
+                            size="sm"
+                            style={{ cursor: "grab" }}
+                            title="Drag to reorder"
+                            onMouseDown={(e) => e.stopPropagation()}
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            <IconGripVertical size={16} />
+                          </ActionIcon>
+                        )}
+                        <ActionIcon
+                          variant="subtle"
+                          size="sm"
+                          onClick={() =>
+                            setExpandedPartId(isExpanded ? null : part.id)
+                          }
+                          disabled={olderBooks.length === 0}
+                          title={olderBooks.length ? "Older revisions" : undefined}
+                        >
+                          {olderBooks.length > 0 ? (
+                            isExpanded ? (
+                              <IconChevronDown size={16} />
+                            ) : (
+                              <IconChevronRight size={16} />
+                            )
+                          ) : (
+                            <IconChevronRight size={16} style={{ opacity: 0.3 }} />
+                          )}
+                        </ActionIcon>
+                        <Text size="sm" fw={600}>
+                          {part.display_name}
+                        </Text>
+                        {latestBook && (
+                          <>
+                            <Badge
+                              size="xs"
+                              variant="light"
+                              color={
+                                latestBook.revision === latestRev ? "teal" : "gray"
+                              }
+                            >
+                              r{latestBook.revision}{" "}
+                              {latestBook.revision === latestRev ? "(latest)" : ""}
+                            </Badge>
+                            {!latestBook.is_rendered && (
+                              <Badge size="xs" variant="light" color="yellow">
+                                Rendering…
+                              </Badge>
+                            )}
+                          </>
+                        )}
+                        {!latestBook && (
+                          <Text size="xs" c="dimmed">
+                            No part book
+                          </Text>
+                        )}
+                      </Group>
+                      {latestBook?.is_rendered && latestBook.download_url && (
+                        <Button
+                          component="a"
+                          href={latestBook.download_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          size="xs"
+                          variant="light"
+                          leftSection={<IconDownload size={14} />}
+                        >
+                          Download
+                        </Button>
+                      )}
+                    </Group>
+                    <Collapse in={isExpanded && olderBooks.length > 0}>
+                      <Stack
+                        gap="xs"
+                        mt="sm"
+                        pl="md"
+                        style={{
+                          borderLeft: "2px solid var(--mantine-color-default-border)",
+                        }}
+                      >
+                        <Text size="xs" c="dimmed" fw={500}>
+                          Older revisions
+                        </Text>
+                        {olderBooks.map((book) => (
+                          <Group key={book.id} justify="space-between">
+                            <Group gap="xs">
+                              <Text size="sm">Revision {book.revision}</Text>
+                              {!book.is_rendered && (
+                                <Badge size="xs" variant="light" color="yellow">
+                                  Rendering…
+                                </Badge>
+                              )}
+                            </Group>
+                            {book.is_rendered && book.download_url && (
+                              <Button
+                                component="a"
+                                href={book.download_url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                size="xs"
+                                variant="subtle"
+                                leftSection={<IconDownload size={12} />}
+                              >
+                                Download
+                              </Button>
+                            )}
+                          </Group>
+                        ))}
+                      </Stack>
+                    </Collapse>
+                  </Card>
+                </div>
+              );
+            })}
+          </Stack>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/apps/frontend/src/pages/ensembles/PartNameMatrixEditor.css
+++ b/apps/frontend/src/pages/ensembles/PartNameMatrixEditor.css
@@ -1,0 +1,36 @@
+.merge-group-start,
+.merge-group-middle,
+.merge-group-end {
+  border-top: 3px solid var(--mantine-color-teal-6);
+}
+
+.merge-group-start {
+  border-left: 3px solid var(--mantine-color-teal-6);
+}
+
+.merge-group-end {
+  border-right: 3px solid var(--mantine-color-teal-6);
+}
+
+.merge-group-middle {
+  border-left: 1px dashed var(--mantine-color-teal-4);
+}
+
+.merge-header-base {
+  background: var(--mantine-color-teal-0);
+}
+
+.merge-header-member {
+  background: var(--mantine-color-teal-0);
+}
+
+.merge-header-drop-target {
+  outline: 2px solid var(--mantine-color-teal-6);
+  outline-offset: -2px;
+}
+
+.merge-connector-bar {
+  background: var(--mantine-color-teal-6);
+  height: 4px;
+  border-radius: 2px 2px 0 0;
+}

--- a/apps/frontend/src/pages/ensembles/PartNameMatrixEditor.tsx
+++ b/apps/frontend/src/pages/ensembles/PartNameMatrixEditor.tsx
@@ -1,0 +1,586 @@
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ActionIcon,
+  Alert,
+  Badge,
+  Box,
+  Button,
+  Group,
+  Loader,
+  Stack,
+  Table,
+  Text,
+  TextInput,
+  Tooltip,
+} from "@mantine/core";
+import { IconGripVertical, IconLink, IconX } from "@tabler/icons-react";
+import { apiService } from "../../services/apiService";
+import { usePartNameMatrix } from "./usePartNameMatrix";
+import {
+  buildDisplayGroups,
+  canLinkColumns,
+  cellKey,
+  getBaseId,
+  getConflictingArrangementIds,
+  getPendingMergeIds,
+  groupCellBorderClass,
+  linkColumnToBase,
+  pairsConflict,
+  unlinkColumn,
+  type DisplayGroup,
+  type MergeLinks,
+} from "./partNameMatrixUtils";
+import "./PartNameMatrixEditor.css";
+
+type Props = {
+  ensembleSlug: string;
+  isAdmin: boolean;
+  onSaved?: () => void;
+};
+
+function ColumnHeader({
+  displayName,
+  isAdmin,
+  isMergeBase,
+  isMember,
+  isDragging,
+  isDropTarget,
+  onDisplayNameChange,
+  onUnlink,
+  onDragHandleStart,
+  onDragHandleEnd,
+}: {
+  displayName: string;
+  isAdmin: boolean;
+  isMergeBase: boolean;
+  isMember: boolean;
+  isDragging: boolean;
+  isDropTarget: boolean;
+  onDisplayNameChange: (value: string) => void;
+  onUnlink?: () => void;
+  onDragHandleStart: (e: React.DragEvent) => void;
+  onDragHandleEnd: (e: React.DragEvent) => void;
+}) {
+  const className = [
+    isMergeBase || isDropTarget ? "merge-header-base" : "",
+    isMember ? "merge-header-member" : "",
+    isDropTarget ? "merge-header-drop-target" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <Stack gap={4} className={className} p={4} style={{ opacity: isDragging ? 0.45 : 1 }}>
+      {isAdmin && (
+        <Group gap={4} wrap="nowrap" justify="space-between">
+          <Box
+            component="span"
+            draggable
+            onDragStart={onDragHandleStart}
+            onDragEnd={onDragHandleEnd}
+            style={{ cursor: "grab", display: "inline-flex", lineHeight: 0 }}
+            title="Drag to merge into another part"
+          >
+            <IconGripVertical size={14} />
+          </Box>
+          {isMergeBase && (
+            <Badge size="xs" variant="filled" color="teal">
+              Base
+            </Badge>
+          )}
+          {isMember && onUnlink && (
+            <Tooltip label="Unlink from merge">
+              <ActionIcon
+                variant="subtle"
+                size="xs"
+                color="gray"
+                onClick={onUnlink}
+                aria-label="Unlink"
+              >
+                <IconX size={12} />
+              </ActionIcon>
+            </Tooltip>
+          )}
+        </Group>
+      )}
+      {isAdmin ? (
+        <TextInput
+          size="xs"
+          value={displayName}
+          onChange={(e) => onDisplayNameChange(e.currentTarget.value)}
+          aria-label={`Part name ${displayName}`}
+        />
+      ) : (
+        <Text size="xs" fw={600} ta="center">
+          {displayName}
+        </Text>
+      )}
+      {isAdmin && isDropTarget && (
+        <Text size="10px" c="dimmed" ta="center">
+          Release to merge here
+        </Text>
+      )}
+      {isAdmin && isMember && (
+        <Group gap={4} justify="center">
+          <IconLink size={12} style={{ color: "var(--mantine-color-teal-6)" }} />
+          <Text size="10px" c="teal">
+            Linked
+          </Text>
+        </Group>
+      )}
+    </Stack>
+  );
+}
+
+export function PartNameMatrixEditor({ ensembleSlug, isAdmin, onSaved }: Props) {
+  const { matrix, loading, error, reload } = usePartNameMatrix(ensembleSlug);
+  const [displayNames, setDisplayNames] = useState<Record<number, string>>({});
+  const [mergeLinks, setMergeLinks] = useState<MergeLinks>({});
+  const [draggedColumnId, setDraggedColumnId] = useState<number | null>(null);
+  const draggedColumnIdRef = useRef<number | null>(null);
+  const [dropTargetBaseId, setDropTargetBaseId] = useState<number | null>(null);
+  const [linkError, setLinkError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!matrix) return;
+    const names: Record<number, string> = {};
+    for (const col of matrix.columns) {
+      names[col.id] = col.display_name;
+    }
+    setDisplayNames(names);
+    setMergeLinks({});
+    setDraggedColumnId(null);
+    draggedColumnIdRef.current = null;
+    setDropTargetBaseId(null);
+    setLinkError(null);
+  }, [matrix]);
+
+  const displayGroups = useMemo(
+    () => (matrix ? buildDisplayGroups(matrix.columns, mergeLinks) : []),
+    [matrix, mergeLinks]
+  );
+
+  const flatColumns = useMemo(
+    () => displayGroups.flatMap((g) => g.columns),
+    [displayGroups]
+  );
+
+  const cellSet = useMemo(() => {
+    const set = new Set<string>();
+    if (!matrix) return set;
+    for (const cell of matrix.cells) {
+      set.add(cellKey(cell.arrangement_id, cell.part_name_id));
+    }
+    return set;
+  }, [matrix]);
+
+  const pendingMergeGroups = useMemo(() => {
+    const baseIds = new Set<number>();
+    for (const memberIdStr of Object.keys(mergeLinks)) {
+      baseIds.add(mergeLinks[Number(memberIdStr)]);
+    }
+    return [...baseIds].map((baseId) => ({
+      baseId,
+      ids: getPendingMergeIds(baseId, mergeLinks),
+    }));
+  }, [mergeLinks]);
+
+  const conflictArrangementIds = useMemo(() => {
+    if (!matrix) return [];
+    const ids: number[] = [];
+    for (const { ids: groupIds } of pendingMergeGroups) {
+      ids.push(...getConflictingArrangementIds(groupIds, matrix.cells));
+    }
+    return [...new Set(ids)];
+  }, [matrix, pendingMergeGroups]);
+
+  const mergeBlocked = useMemo(() => {
+    if (!matrix) return false;
+    for (const { ids } of pendingMergeGroups) {
+      if (ids.length < 2) continue;
+      if (pairsConflict(ids, matrix.merge_conflicts)) return true;
+      if (getConflictingArrangementIds(ids, matrix.cells).length > 0) return true;
+    }
+    return false;
+  }, [matrix, pendingMergeGroups]);
+
+  const dirtyRenames = useMemo(() => {
+    if (!matrix) return [];
+    const mergingIds = new Set(Object.keys(mergeLinks).map(Number));
+    for (const { baseId, ids } of pendingMergeGroups) {
+      ids.forEach((id) => mergingIds.add(id));
+      mergingIds.add(baseId);
+    }
+    return matrix.columns.filter((col) => {
+      const newName = (displayNames[col.id] ?? col.display_name).trim();
+      return newName !== col.display_name && !mergingIds.has(col.id);
+    });
+  }, [matrix, displayNames, mergeLinks, pendingMergeGroups]);
+
+  const hasPendingMerges = Object.keys(mergeLinks).length > 0;
+  const hasChanges =
+    dirtyRenames.length > 0 || (hasPendingMerges && !mergeBlocked);
+
+  const clearDragState = () => {
+    draggedColumnIdRef.current = null;
+    setDraggedColumnId(null);
+    setDropTargetBaseId(null);
+  };
+
+  const handleDragHandleStart = (columnId: number) => (e: React.DragEvent) => {
+    if (!isAdmin) return;
+    e.stopPropagation();
+    draggedColumnIdRef.current = columnId;
+    setDraggedColumnId(columnId);
+    setLinkError(null);
+    e.dataTransfer.effectAllowed = "move";
+    e.dataTransfer.setData("application/x-part-name-id", String(columnId));
+    e.dataTransfer.setData("text/plain", String(columnId));
+  };
+
+  const handleDragHandleEnd = () => {
+    clearDragState();
+  };
+
+  const handleHeaderDragOver = (targetColumnId: number) => (e: React.DragEvent) => {
+    const sourceId = draggedColumnIdRef.current;
+    if (!isAdmin || sourceId === null || !matrix) return;
+
+    const check = canLinkColumns(
+      sourceId,
+      targetColumnId,
+      mergeLinks,
+      matrix.cells,
+      matrix.merge_conflicts
+    );
+    if (!check.ok) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+    e.dataTransfer.dropEffect = "move";
+    setDropTargetBaseId(getBaseId(targetColumnId, mergeLinks));
+  };
+
+  const handleHeaderDrop = (targetColumnId: number) => (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const sourceId = draggedColumnIdRef.current;
+    if (!isAdmin || sourceId === null || !matrix) {
+      clearDragState();
+      return;
+    }
+
+    const check = canLinkColumns(
+      sourceId,
+      targetColumnId,
+      mergeLinks,
+      matrix.cells,
+      matrix.merge_conflicts
+    );
+
+    if (!check.ok) {
+      setLinkError(check.reason);
+      clearDragState();
+      return;
+    }
+
+    const targetBase = getBaseId(targetColumnId, mergeLinks);
+    setMergeLinks((prev) => linkColumnToBase(sourceId, targetBase, prev));
+    setLinkError(null);
+    clearDragState();
+  };
+
+  const handleSave = useCallback(async () => {
+    if (!matrix || !isAdmin) return;
+    setSaving(true);
+    setSaveError(null);
+
+    try {
+      for (const col of dirtyRenames) {
+        const newName = (displayNames[col.id] ?? col.display_name).trim();
+        if (!newName) throw new Error("Part names cannot be empty.");
+        await apiService.renamePartName(ensembleSlug, col.id, newName);
+      }
+
+      if (hasPendingMerges) {
+        if (mergeBlocked) {
+          throw new Error(
+            "Cannot merge: linked part names both have parts in the same arrangement version."
+          );
+        }
+
+        for (const { baseId, ids } of pendingMergeGroups) {
+          const mergeIds = ids.filter((id) => id !== baseId);
+          if (mergeIds.length === 0) continue;
+          const finalName = (displayNames[baseId] ?? "").trim();
+          for (const otherId of mergeIds) {
+            await apiService.mergePartNames(
+              ensembleSlug,
+              baseId,
+              otherId,
+              finalName || null
+            );
+          }
+        }
+      }
+
+      await reload();
+      onSaved?.();
+    } catch (err: unknown) {
+      setSaveError(err instanceof Error ? err.message : String(err));
+      await reload();
+    } finally {
+      setSaving(false);
+    }
+  }, [
+    matrix,
+    isAdmin,
+    dirtyRenames,
+    displayNames,
+    hasPendingMerges,
+    mergeBlocked,
+    pendingMergeGroups,
+    ensembleSlug,
+    reload,
+    onSaved,
+  ]);
+
+  const renderHeaderCells = (group: DisplayGroup) =>
+    group.columns.map((col) => {
+      const isBase = group.kind === "merge" && col.id === group.baseId;
+      const isMember = group.kind === "merge" && col.id !== group.baseId;
+      const borderClass = groupCellBorderClass(group, col.id);
+      const isDropTarget =
+        isAdmin && dropTargetBaseId !== null && col.id === dropTargetBaseId;
+
+      const thProps = isAdmin
+        ? {
+            onDragOver: handleHeaderDragOver(col.id),
+            onDragLeave: () => setDropTargetBaseId(null),
+            onDrop: handleHeaderDrop(col.id),
+          }
+        : {};
+
+      return (
+        <Table.Th
+          key={col.id}
+          className={borderClass}
+          style={{
+            minWidth: 120,
+            verticalAlign: "bottom",
+            padding: 0,
+          }}
+          {...thProps}
+        >
+          <ColumnHeader
+            displayName={displayNames[col.id] ?? col.display_name}
+            isAdmin={isAdmin}
+            isMergeBase={isBase}
+            isMember={isMember}
+            isDragging={draggedColumnId === col.id}
+            isDropTarget={isDropTarget}
+            onDisplayNameChange={(value) =>
+              setDisplayNames((prev) => ({ ...prev, [col.id]: value }))
+            }
+            onUnlink={
+              isMember
+                ? () => setMergeLinks((prev) => unlinkColumn(col.id, prev))
+                : undefined
+            }
+            onDragHandleStart={handleDragHandleStart(col.id)}
+            onDragHandleEnd={handleDragHandleEnd}
+          />
+        </Table.Th>
+      );
+    });
+
+  const renderBodyCells = (arrangementId: number, group: DisplayGroup) =>
+    group.columns.map((col) => {
+      const filled = cellSet.has(cellKey(arrangementId, col.id));
+      const borderClass = groupCellBorderClass(group, col.id);
+      return (
+        <Table.Td key={col.id} ta="center" className={borderClass}>
+          {filled ? (
+            <Text size="lg" c="teal" aria-label="Has part">
+              ●
+            </Text>
+          ) : (
+            <Text size="sm" c="dimmed">
+              —
+            </Text>
+          )}
+        </Table.Td>
+      );
+    });
+
+  if (loading) {
+    return (
+      <Group justify="center" py="md">
+        <Loader size="sm" />
+        <Text size="sm" c="dimmed">
+          Loading part names…
+        </Text>
+      </Group>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert color="red" title="Could not load part names">
+        {error}
+      </Alert>
+    );
+  }
+
+  if (!matrix || matrix.columns.length === 0) {
+    return (
+      <Text size="sm" c="dimmed">
+        No part names yet. Part names are added when you upload arrangement versions with parts.
+      </Text>
+    );
+  }
+
+  return (
+    <Stack gap="sm">
+      <Text size="xs" c="dimmed">
+        Each row is an arrangement; each column is a part name.{" "}
+        {isAdmin &&
+          "Use the grip (⠿) on a column and drag it onto the part you want to keep. You cannot merge two names that both have a part in the same arrangement."}
+      </Text>
+
+      {linkError && (
+        <Alert color="red" onClose={() => setLinkError(null)} withCloseButton>
+          {linkError}
+        </Alert>
+      )}
+
+      {saveError && (
+        <Alert color="red" onClose={() => setSaveError(null)} withCloseButton>
+          {saveError}
+        </Alert>
+      )}
+
+      {mergeBlocked && isAdmin && hasPendingMerges && (
+        <Alert color="orange" title="Merge blocked">
+          Linked part names both have parts in the same arrangement version
+          {conflictArrangementIds.length > 0 && (
+            <>
+              {" "}
+              for{" "}
+              {conflictArrangementIds
+                .map((id) => matrix.arrangements.find((a) => a.id === id)?.title ?? id)
+                .join(", ")}
+            </>
+          )}
+          . Unlink a column before saving.
+        </Alert>
+      )}
+
+      <Table.ScrollContainer minWidth={900} type="native" style={{ maxWidth: "100%" }}>
+        <Table striped highlightOnHover withTableBorder withColumnBorders stickyHeader>
+          <Table.Thead>
+            {displayGroups.some((g) => g.kind === "merge") && (
+              <Table.Tr>
+                <Table.Th
+                  style={{ position: "sticky", left: 0, zIndex: 3, background: "var(--mantine-color-body)" }}
+                />
+                {displayGroups.map((group) =>
+                  group.kind === "merge" ? (
+                    <Table.Th
+                      key={`connector-${group.baseId}`}
+                      colSpan={group.columns.length}
+                      p={0}
+                      style={{ verticalAlign: "bottom", border: "none" }}
+                    >
+                      <Box className="merge-connector-bar" mx={4} />
+                    </Table.Th>
+                  ) : (
+                    <Table.Th key={`connector-solo-${group.columns[0].id}`} p={0} style={{ border: "none" }} />
+                  )
+                )}
+              </Table.Tr>
+            )}
+            <Table.Tr>
+              <Table.Th
+                style={{
+                  minWidth: 140,
+                  position: "sticky",
+                  left: 0,
+                  zIndex: 2,
+                  background: "var(--mantine-color-body)",
+                }}
+              >
+                Arrangement
+              </Table.Th>
+              {displayGroups.map((group) => (
+                <Fragment key={group.kind === "merge" ? `h-${group.baseId}` : `h-${group.columns[0].id}`}>
+                  {renderHeaderCells(group)}
+                </Fragment>
+              ))}
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {matrix.arrangements.length === 0 ? (
+              <Table.Tr>
+                <Table.Td colSpan={flatColumns.length + 1}>
+                  <Text size="sm" c="dimmed">
+                    No arrangements in this ensemble.
+                  </Text>
+                </Table.Td>
+              </Table.Tr>
+            ) : (
+              matrix.arrangements.map((arr) => {
+                const rowConflict = conflictArrangementIds.includes(arr.id);
+                return (
+                  <Table.Tr
+                    key={arr.id}
+                    style={
+                      rowConflict
+                        ? { backgroundColor: "var(--mantine-color-red-0)" }
+                        : undefined
+                    }
+                  >
+                    <Table.Td
+                      style={{
+                        position: "sticky",
+                        left: 0,
+                        background: rowConflict
+                          ? "var(--mantine-color-red-0)"
+                          : "var(--mantine-color-body)",
+                        zIndex: 1,
+                      }}
+                    >
+                      <Text size="sm" fw={500}>
+                        {arr.mvt_no ? `${arr.mvt_no}. ` : ""}
+                        {arr.title}
+                      </Text>
+                    </Table.Td>
+                    {displayGroups.map((group) => (
+                      <Fragment key={group.kind === "merge" ? `b-${arr.id}-${group.baseId}` : `b-${arr.id}-${group.columns[0].id}`}>
+                        {renderBodyCells(arr.id, group)}
+                      </Fragment>
+                    ))}
+                  </Table.Tr>
+                );
+              })
+            )}
+          </Table.Tbody>
+        </Table>
+      </Table.ScrollContainer>
+
+      {isAdmin && (
+        <Group justify="flex-end">
+          <Button variant="light" size="sm" onClick={() => reload()} disabled={saving}>
+            Reset
+          </Button>
+          <Button size="sm" onClick={handleSave} loading={saving} disabled={!hasChanges}>
+            Save changes
+          </Button>
+        </Group>
+      )}
+    </Stack>
+  );
+}

--- a/apps/frontend/src/pages/ensembles/partNameMatrixUtils.test.ts
+++ b/apps/frontend/src/pages/ensembles/partNameMatrixUtils.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDisplayGroups,
+  canLinkColumns,
+  getConflictingArrangementIds,
+  linkColumnToBase,
+  unlinkColumn,
+} from "./partNameMatrixUtils";
+import type { PartNameMatrixColumn } from "../../services/apiService";
+
+const columns: PartNameMatrixColumn[] = [
+  { id: 1, display_name: "Flute", order: 0 },
+  { id: 2, display_name: "Flute I", order: 1 },
+  { id: 3, display_name: "Clarinet", order: 2 },
+];
+
+describe("partNameMatrixUtils", () => {
+  it("groups linked columns adjacent to base", () => {
+    const links = { 2: 1 };
+    const groups = buildDisplayGroups(columns, links);
+    expect(groups).toHaveLength(2);
+    expect(groups[0]).toMatchObject({ kind: "merge", baseId: 1 });
+    expect(groups[0].kind === "merge" && groups[0].columns.map((c) => c.id)).toEqual([
+      1, 2,
+    ]);
+    expect(groups[1].kind).toBe("standalone");
+  });
+
+  it("links a column onto a base and re-parents former members", () => {
+    const links = linkColumnToBase(3, 1, { 2: 1 });
+    expect(links).toEqual({ 2: 1, 3: 1 });
+  });
+
+  it("unlinks a member column", () => {
+    const links = unlinkColumn(2, { 2: 1 });
+    expect(links).toEqual({});
+  });
+
+  it("detects conflicting arrangements when both parts exist on same row", () => {
+    const cells = [
+      { arrangement_id: 10, part_name_id: 1, part_asset_id: 100 },
+      { arrangement_id: 10, part_name_id: 2, part_asset_id: 101 },
+    ];
+    expect(getConflictingArrangementIds([1, 2], cells)).toEqual([10]);
+    expect(getConflictingArrangementIds([1], cells)).toEqual([]);
+  });
+
+  it("rejects link when merge would duplicate parts in same version", () => {
+    const cells = [
+      { arrangement_id: 10, part_name_id: 1, part_asset_id: 100 },
+      { arrangement_id: 10, part_name_id: 2, part_asset_id: 101 },
+    ];
+    const result = canLinkColumns(2, 1, {}, cells, []);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("same arrangement version");
+    }
+  });
+
+  it("allows link when parts are on different arrangements", () => {
+    const cells = [
+      { arrangement_id: 10, part_name_id: 1, part_asset_id: 100 },
+      { arrangement_id: 11, part_name_id: 2, part_asset_id: 101 },
+    ];
+    expect(canLinkColumns(2, 1, {}, cells, [])).toEqual({ ok: true });
+  });
+});

--- a/apps/frontend/src/pages/ensembles/partNameMatrixUtils.ts
+++ b/apps/frontend/src/pages/ensembles/partNameMatrixUtils.ts
@@ -1,0 +1,194 @@
+import type {
+  PartNameMatrixCell,
+  PartNameMatrixColumn,
+} from "../../services/apiService";
+
+export type MergeLinks = Record<number, number>;
+
+export type DisplayGroup =
+  | { kind: "standalone"; columns: PartNameMatrixColumn[] }
+  | { kind: "merge"; baseId: number; columns: PartNameMatrixColumn[] };
+
+export function getBaseId(columnId: number, mergeLinks: MergeLinks): number {
+  return mergeLinks[columnId] ?? columnId;
+}
+
+export function getGroupMemberIds(baseId: number, mergeLinks: MergeLinks): number[] {
+  return Object.entries(mergeLinks)
+    .filter(([, base]) => base === baseId)
+    .map(([memberId]) => Number(memberId));
+}
+
+export function getPendingMergeIds(baseId: number, mergeLinks: MergeLinks): number[] {
+  return [baseId, ...getGroupMemberIds(baseId, mergeLinks)];
+}
+
+export function buildDisplayGroups(
+  columns: PartNameMatrixColumn[],
+  mergeLinks: MergeLinks
+): DisplayGroup[] {
+  const memberIds = new Set(Object.keys(mergeLinks).map(Number));
+  const membersByBase = new Map<number, number[]>();
+
+  for (const [memberIdStr, baseId] of Object.entries(mergeLinks)) {
+    const memberId = Number(memberIdStr);
+    if (!membersByBase.has(baseId)) membersByBase.set(baseId, []);
+    membersByBase.get(baseId)!.push(memberId);
+  }
+
+  const columnIndex = new Map(columns.map((c, i) => [c.id, i]));
+  const sortByColumnOrder = (a: number, b: number) =>
+    (columnIndex.get(a) ?? 0) - (columnIndex.get(b) ?? 0);
+
+  const groups: DisplayGroup[] = [];
+
+  for (const col of columns) {
+    if (memberIds.has(col.id)) continue;
+
+    const memberIdsForBase = (membersByBase.get(col.id) ?? []).sort(sortByColumnOrder);
+    const memberCols = memberIdsForBase
+      .map((id) => columns.find((c) => c.id === id))
+      .filter((c): c is PartNameMatrixColumn => c != null);
+
+    if (memberCols.length > 0) {
+      groups.push({ kind: "merge", baseId: col.id, columns: [col, ...memberCols] });
+    } else {
+      groups.push({ kind: "standalone", columns: [col] });
+    }
+  }
+
+  return groups;
+}
+
+export function linkColumnToBase(
+  sourceId: number,
+  targetBaseId: number,
+  mergeLinks: MergeLinks
+): MergeLinks {
+  if (sourceId === targetBaseId) return mergeLinks;
+
+  const next: MergeLinks = { ...mergeLinks };
+  const sourceBase = getBaseId(sourceId, next);
+  const sourceMembers = getGroupMemberIds(sourceBase, next);
+
+  for (const memberId of sourceMembers) {
+    next[memberId] = targetBaseId;
+  }
+
+  if (sourceId !== sourceBase) {
+    delete next[sourceId];
+  }
+
+  next[sourceId] = targetBaseId;
+
+  return next;
+}
+
+export function unlinkColumn(memberId: number, mergeLinks: MergeLinks): MergeLinks {
+  const next = { ...mergeLinks };
+  delete next[memberId];
+  return next;
+}
+
+export function pairsConflict(selectedIds: number[], mergeConflicts: [number, number][]) {
+  const selected = new Set(selectedIds);
+  return mergeConflicts.some(([a, b]) => selected.has(a) && selected.has(b));
+}
+
+/** Arrangements where more than one of the given part names has a part (latest version). */
+export function getConflictingArrangementIds(
+  partNameIds: number[],
+  cells: PartNameMatrixCell[]
+): number[] {
+  if (partNameIds.length < 2) return [];
+
+  const idSet = new Set(partNameIds);
+  const partNamesPerArrangement = new Map<number, Set<number>>();
+
+  for (const cell of cells) {
+    if (!idSet.has(cell.part_name_id)) continue;
+    let parts = partNamesPerArrangement.get(cell.arrangement_id);
+    if (!parts) {
+      parts = new Set();
+      partNamesPerArrangement.set(cell.arrangement_id, parts);
+    }
+    parts.add(cell.part_name_id);
+  }
+
+  const conflicts: number[] = [];
+  for (const [arrangementId, parts] of partNamesPerArrangement) {
+    const overlapCount = partNameIds.filter((id) => parts.has(id)).length;
+    if (overlapCount >= 2) conflicts.push(arrangementId);
+  }
+  return conflicts;
+}
+
+export function getIdsAfterLink(
+  sourceId: number,
+  targetBaseId: number,
+  mergeLinks: MergeLinks
+): number[] {
+  return getPendingMergeIds(targetBaseId, linkColumnToBase(sourceId, targetBaseId, mergeLinks));
+}
+
+export function canLinkColumns(
+  sourceId: number,
+  targetColumnId: number,
+  mergeLinks: MergeLinks,
+  cells: PartNameMatrixCell[],
+  mergeConflicts: [number, number][]
+): { ok: true } | { ok: false; reason: string; arrangementIds?: number[] } {
+  const targetBase = getBaseId(targetColumnId, mergeLinks);
+  const sourceBase = getBaseId(sourceId, mergeLinks);
+
+  if (sourceId === targetBase) {
+    return { ok: false, reason: "Cannot merge a part name into itself." };
+  }
+
+  const sourceMembers = getGroupMemberIds(sourceBase, mergeLinks);
+  if (sourceMembers.includes(targetBase)) {
+    return { ok: false, reason: "That part is already linked to this base." };
+  }
+
+  if (targetBase === sourceBase) {
+    return { ok: false, reason: "That part is already the base for this group." };
+  }
+
+  const mergedIds = getIdsAfterLink(sourceId, targetBase, mergeLinks);
+
+  if (pairsConflict(mergedIds, mergeConflicts)) {
+    return {
+      ok: false,
+      reason:
+        "Cannot merge: these part names both have parts in the same arrangement version.",
+    };
+  }
+
+  const conflictArrangementIds = getConflictingArrangementIds(mergedIds, cells);
+  if (conflictArrangementIds.length > 0) {
+    return {
+      ok: false,
+      reason:
+        "Cannot merge: these part names both have parts in the same arrangement version.",
+      arrangementIds: conflictArrangementIds,
+    };
+  }
+
+  return { ok: true };
+}
+
+export function cellKey(arrangementId: number, partNameId: number) {
+  return `${arrangementId}-${partNameId}`;
+}
+
+export function groupCellBorderClass(
+  group: DisplayGroup,
+  columnId: number
+): string | undefined {
+  if (group.kind !== "merge" || group.columns.length < 2) return undefined;
+  const idx = group.columns.findIndex((c) => c.id === columnId);
+  if (idx < 0) return undefined;
+  if (idx === 0) return "merge-group-start";
+  if (idx === group.columns.length - 1) return "merge-group-end";
+  return "merge-group-middle";
+}

--- a/apps/frontend/src/pages/ensembles/usePartNameMatrix.ts
+++ b/apps/frontend/src/pages/ensembles/usePartNameMatrix.ts
@@ -1,0 +1,29 @@
+import { useCallback, useEffect, useState } from "react";
+import { apiService, type PartNameMatrix } from "../../services/apiService";
+
+export function usePartNameMatrix(ensembleSlug: string) {
+  const [matrix, setMatrix] = useState<PartNameMatrix | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!ensembleSlug) return;
+    try {
+      setLoading(true);
+      setError(null);
+      const data = await apiService.getPartNameMatrix(ensembleSlug);
+      setMatrix(data);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err));
+      setMatrix(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [ensembleSlug]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return { matrix, loading, error, reload: load };
+}


### PR DESCRIPTION
## Description
Rn Part Book Functionality is a pain to use because the old part name merger sucked. By improving this I hope the utility of the part books is increased

Next Steps:
- improve part books by using html templates not whatever bs I am doing now with reportlab :skull:


## Which app(s)/packages is this PR for?

=== Apps ===
- [x] Backend
- [ ] Musescore Headless
- [x] Frontend

=== Packages ===
- [ ] Part Formatter
- [ ] Score Diff
- [ ] Scoreforge


Optional:
Shortcut ticket link: